### PR TITLE
Feature open hours

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1483,7 +1483,7 @@ function kbs_support_hours_callback( $args ) {
 	$mins = array( '00', '15', '30', '45' );
 	$ampm = array( 'AM', 'PM' );
 
-	$html = '<table style="width: 50%;">';
+	$html = '<table style="width: 75%;">';
 		$html .= '<tr>';
 			$html .= '<th scope="row">' . __( 'Day of Week', 'kb-support' ) . '</th>';
 			$html .= '<th scope="row">' . __( 'Closed all Day', 'kb-support' ) . '</th>';
@@ -1950,24 +1950,25 @@ function kbs_get_pages( $force = false ) {
  */
 function kbs_get_response_time_options()	{
 	$response_times = array(
-		HOUR_IN_SECONDS     => __( '1 Hour', 'kb-support' ),
-		2 * HOUR_IN_SECONDS => __( '2 Hours', 'kb-support' ),
-		3 * HOUR_IN_SECONDS => __( '3 Hours', 'kb-support' ),
-		4 * HOUR_IN_SECONDS => __( '4 Hours', 'kb-support' ),
-		5 * HOUR_IN_SECONDS => __( '5 Hours', 'kb-support' ),
-		6 * HOUR_IN_SECONDS => __( '6 Hours', 'kb-support' ),
-		7 * HOUR_IN_SECONDS => __( '7 Hours', 'kb-support' ),
-		8 * HOUR_IN_SECONDS => __( '8 Hours', 'kb-support' ),
-		DAY_IN_SECONDS      => __( '1 Day', 'kb-support' ),
-		2 * DAY_IN_SECONDS  => __( '2 Days', 'kb-support' ),
-		3 * DAY_IN_SECONDS  => __( '3 Days', 'kb-support' ),
-		4 * DAY_IN_SECONDS  => __( '4 Days', 'kb-support' ),
-		5 * DAY_IN_SECONDS  => __( '5 Days', 'kb-support' ),
-		6 * DAY_IN_SECONDS  => __( '6 Days', 'kb-support' ),
-		WEEK_IN_SECONDS     => __( '1 Week', 'kb-support' ),
-		2 * WEEK_IN_SECONDS => __( '2 Weeks', 'kb-support' ),
-		3 * WEEK_IN_SECONDS => __( '3 Weeks', 'kb-support' ),
-		4 * WEEK_IN_SECONDS => __( '4 Weeks', 'kb-support' )
+		HOUR_IN_SECONDS      => __( '1 Hour', 'kb-support' ),
+		2 * HOUR_IN_SECONDS  => __( '2 Hours', 'kb-support' ),
+		3 * HOUR_IN_SECONDS  => __( '3 Hours', 'kb-support' ),
+		4 * HOUR_IN_SECONDS  => __( '4 Hours', 'kb-support' ),
+		5 * HOUR_IN_SECONDS  => __( '5 Hours', 'kb-support' ),
+		6 * HOUR_IN_SECONDS  => __( '6 Hours', 'kb-support' ),
+		7 * HOUR_IN_SECONDS  => __( '7 Hours', 'kb-support' ),
+		8 * HOUR_IN_SECONDS  => __( '8 Hours', 'kb-support' ),
+		12 * HOUR_IN_SECONDS => __( '12 Hours', 'kb-support' ),
+		DAY_IN_SECONDS       => __( '1 Day', 'kb-support' ),
+		2 * DAY_IN_SECONDS   => __( '2 Days', 'kb-support' ),
+		3 * DAY_IN_SECONDS   => __( '3 Days', 'kb-support' ),
+		4 * DAY_IN_SECONDS   => __( '4 Days', 'kb-support' ),
+		5 * DAY_IN_SECONDS   => __( '5 Days', 'kb-support' ),
+		6 * DAY_IN_SECONDS   => __( '6 Days', 'kb-support' ),
+		WEEK_IN_SECONDS      => __( '1 Week', 'kb-support' ),
+		2 * WEEK_IN_SECONDS  => __( '2 Weeks', 'kb-support' ),
+		3 * WEEK_IN_SECONDS  => __( '3 Weeks', 'kb-support' ),
+		4 * WEEK_IN_SECONDS  => __( '4 Weeks', 'kb-support' )
 	);
 
 	return apply_filters( 'kbs_get_response_time_options', $response_times );
@@ -1983,16 +1984,25 @@ function kbs_get_response_time_options()	{
  */
 function kbs_get_resolve_time_options()	{
 	$resolve_times = array(
-		DAY_IN_SECONDS      => __( '1 Day', 'kb-support' ),
-		2 * DAY_IN_SECONDS  => __( '2 Days', 'kb-support' ),
-		3 * DAY_IN_SECONDS  => __( '3 Days', 'kb-support' ),
-		4 * DAY_IN_SECONDS  => __( '4 Days', 'kb-support' ),
-		5 * DAY_IN_SECONDS  => __( '5 Days', 'kb-support' ),
-		6 * DAY_IN_SECONDS  => __( '6 Days', 'kb-support' ),
-		WEEK_IN_SECONDS     => __( '1 Week', 'kb-support' ),
-		2 * WEEK_IN_SECONDS => __( '2 Weeks', 'kb-support' ),
-		3 * WEEK_IN_SECONDS => __( '3 Weeks', 'kb-support' ),
-		4 * WEEK_IN_SECONDS => __( '4 Weeks', 'kb-support' )
+		HOUR_IN_SECONDS      => __( '1 Hour', 'kb-support' ),
+		2 * HOUR_IN_SECONDS  => __( '2 Hours', 'kb-support' ),
+		3 * HOUR_IN_SECONDS  => __( '3 Hours', 'kb-support' ),
+		4 * HOUR_IN_SECONDS  => __( '4 Hours', 'kb-support' ),
+		5 * HOUR_IN_SECONDS  => __( '5 Hours', 'kb-support' ),
+		6 * HOUR_IN_SECONDS  => __( '6 Hours', 'kb-support' ),
+		7 * HOUR_IN_SECONDS  => __( '7 Hours', 'kb-support' ),
+		8 * HOUR_IN_SECONDS  => __( '8 Hours', 'kb-support' ),
+		12 * HOUR_IN_SECONDS => __( '12 Hours', 'kb-support' ),
+		DAY_IN_SECONDS       => __( '1 Day', 'kb-support' ),
+		2 * DAY_IN_SECONDS   => __( '2 Days', 'kb-support' ),
+		3 * DAY_IN_SECONDS   => __( '3 Days', 'kb-support' ),
+		4 * DAY_IN_SECONDS   => __( '4 Days', 'kb-support' ),
+		5 * DAY_IN_SECONDS   => __( '5 Days', 'kb-support' ),
+		6 * DAY_IN_SECONDS   => __( '6 Days', 'kb-support' ),
+		WEEK_IN_SECONDS      => __( '1 Week', 'kb-support' ),
+		2 * WEEK_IN_SECONDS  => __( '2 Weeks', 'kb-support' ),
+		3 * WEEK_IN_SECONDS  => __( '3 Weeks', 'kb-support' ),
+		4 * WEEK_IN_SECONDS  => __( '4 Weeks', 'kb-support' )
 	);
 	
 	return apply_filters( 'kbs_target_resolve_time_options', $resolve_times );

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -15,11 +15,6 @@
 if ( ! defined( 'ABSPATH' ) )
 	exit;
 
-function mh_test()	{
-	error_log( kbs_get_working_time_in_day() );
-}
-add_action( 'init', 'mh_test' );
-
 /**
  * Check if AJAX works as expected
  *

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -15,6 +15,11 @@
 if ( ! defined( 'ABSPATH' ) )
 	exit;
 
+function mh_test()	{
+	error_log( kbs_get_working_time_in_day() );
+}
+add_action( 'init', 'mh_test' );
+
 /**
  * Check if AJAX works as expected
  *

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -332,6 +332,34 @@ function kbs_get_notices( $notice = '', $notice_only = false )	{
 } // kbs_get_notices
 
 /**
+ * Retrieve days of week.
+ *
+ * @since	1.0
+ * @return	arr		Array of days of week values. $day_number => $day_name
+ */
+function kbs_get_days_of_week()	{
+	global $wp_locale;
+
+	$days_of_week = array();
+	$week_start   = get_option( 'start_of_week' );
+
+	$days_of_week[ $week_start ] = $wp_locale->get_weekday( $week_start );
+
+	for( $day_index = 0; $day_index <= 6; $day_index++ )	{
+		if ( '1' == $week_start && '0' == $day_index )	{
+			continue;
+		}
+		$days_of_week[ $day_index ] = $wp_locale->get_weekday( $day_index );
+	}
+
+	if ( '1' == $week_start )	{
+		$days_of_week[ 0 ] = $wp_locale->get_weekday( 0 );
+	}
+
+	return $days_of_week;
+} // kbs_get_days_of_week
+
+/**
  * Adds credit information after the ticket and reply form.
  *
  * @since	1.0

--- a/includes/sla.php
+++ b/includes/sla.php
@@ -37,8 +37,28 @@ function kbs_calculate_sla_target_response()	{
 	$target = kbs_get_option( 'sla_response_time' );
 
 	if ( $target )	{
-		$target = strtotime( '+' . $target, $now );
-		$target = date( 'Y-m-d H:i:s', $target );
+		$target_response = $target + $now;
+
+		if ( kbs_use_support_hours() )	{
+			$work_hours_remaining = kbs_get_remaining_work_time();
+
+			if ( ! $work_hours_remaining )	{
+				$work_hours_remaining = 0;
+			}
+
+			if ( $now + $hours_remaining < $target_response )	{
+				$next_working_day  = kbs_get_next_working_day();
+				$hours_in_next_day = kbs_get_working_time_in_day( $next_working_day );
+
+				$hours_to_add = $target - $hours_remaining;
+
+				$target_response = strtotime( '+' . $target, $next_working_day );
+				$target_response = $target_response - $hours_remaining;
+			}
+
+		}
+
+		$target = date( 'Y-m-d H:i:s', $target_response );
 	}
 	
 	return apply_filters( 'kbs_calculate_sla_target_response', $target );
@@ -56,7 +76,7 @@ function kbs_calculate_sla_target_resolution()	{
 	$target = kbs_get_option( 'sla_resolve_time' );
 
 	if ( $target )	{
-		$target = strtotime( '+' . $target, $now );
+		$target = $target + $now;
 		$target = date( 'Y-m-d H:i:s', $target );
 	}
 	
@@ -369,3 +389,152 @@ function kbs_time_to_target( $ticket_id )	{
 	
 	return $kbs_ticket->get_sla_remain();
 } // kbs_time_to_target_response
+
+/* ------------------------------
+	SUPPORT HOURS
+-------------------------------*/
+/**
+ * Whether or not to use support hours.
+ *
+ * @since	1.0
+ * @return	bool	True if we should use support hours, otherwise false
+ */
+function kbs_use_support_hours()	{
+	$use_hours = kbs_get_option( 'define_support_hours', false );
+	return apply_filters( 'kbs_use_support_hours', $use_hours );
+} // kbs_use_support_hours
+
+/**
+ * Retrieve support hours.
+ *
+ * @since	1.0
+ * @return	arr		Array of all working times
+ */
+function kbs_get_support_hours()	{
+	if ( ! kbs_use_support_hours() )	{
+		return false;
+	}
+
+	$hours = kbs_get_option( 'support_hours', false );
+
+	return apply_filters( 'kbs_support_hours', $hours );
+} // kbs_get_support_hours
+
+/**
+ * Retrieve the amount of working time in a given day.
+ *
+ * @since	1.0
+ * @param	int|str	$date	The date to check. Can be a unix timestamp or string
+ *							See PHP `date()` function for formatting strings
+ * @return	int		Total number of seconds in working day
+ */
+function kbs_get_working_time_in_day( $date = false )	{
+
+	if ( empty( $date ) )	{
+		$date = strtotime( date( 'Y-m-d', current_time( 'timestamp' ) ) );
+	} elseif ( ! is_numeric( $date ) )	{
+		$date = strtotime( date( 'Y-m-d', $date ) );
+	}
+
+	$day           = date( 'w', $date );
+	$working_times = kbs_get_support_hours();
+	$open_hour     = ! empty( $working_times[ $day ]['open']['hour'] ) ? $working_times[ $day ]['open']['hour'] : '-1';
+	$open_minute   = ! empty( $working_times[ $day ]['open']['min'] )  ? $working_times[ $day ]['open']['min']  : '-1';
+	$close_hour    = ! empty( $working_times[ $day ]['close']['hour'] ) ? $working_times[ $day ]['close']['hour'] : '-1';
+	$close_minute  = ! empty( $working_times[ $day ]['close']['min'] )  ? $working_times[ $day ]['close']['min']  : '-1';
+
+	if ( ! empty( $working_times[ $day ]['closed'] ) )	{
+		return 0;
+	}
+
+	if ( '-1' == $open_hour || '-1' == $open_minute || '-1' == $close_hour || '-1' == $close_minute )	{
+		return 0;
+	}
+	$open  = strtotime( date( 'Y-m-d ' . $open_hour  . ':' . $open_minute  . ':00', $date ) );
+	$close = strtotime( date( 'Y-m-d ' . $close_hour . ':' . $close_minute . ':00', $date ) );
+
+	$seconds_in_work_day = $close - $open;
+
+	return apply_filters( 'kbs_remaining_work_time_in_day', $seconds_in_work_day );
+
+} // kbs_get_working_time_in_day
+
+/**
+ * Retrieve remaining working time for today.
+ *
+ * @since	1.0
+ * @return	int|bool	Number of seconds of work time remaining, or false if already closed
+ */
+function kbs_get_remaining_work_time( $day = 'w' )	{
+
+	$day = date( $day );
+	$working_times = kbs_get_support_hours();
+	$now           = date( 'Y-m-d H:i:s', current_time( 'timestamp' ) );
+	$close_hour    = ! empty( $working_times[ $day ]['close']['hour'] ) ? $working_times[ $day ]['close']['hour'] : '-1';
+	$close_minute  = ! empty( $working_times[ $day ]['close']['min'] )  ? $working_times[ $day ]['close']['min']  : '-1';
+
+	if ( ! empty( $working_times[ $day ]['closed'] ) )	{
+		return false;
+	}
+
+	if ( '-1' == $close_hour || '-1' == $close_minute )	{
+		return false;
+	}
+
+	$close         = new DateTime();
+
+	$close->setTime( $close_hour, $close_minute );
+	$close_time = $close->format( 'U' );
+	$return     = false;
+
+	if ( strtotime( $now ) < $close_time )	{
+		$return = $close_time - strtotime( $now );
+	}
+
+	return apply_filters( 'kbs_remaining_work_time', $return );
+
+} // kbs_get_remaining_work_time
+
+/**
+ * Retrieve the next working day.
+ *
+ * @since	1.0
+ * @param	int		$from	The timestamp from which to find the next working day
+ * @return	int		Unix timestamp representation of the next working day start time
+ */
+function kbs_get_next_working_day( $from = false )	{
+
+	if ( ! $from || ! is_numeric( $from ) )	{
+		$from = current_time( 'timestamp' );
+	}
+
+	$current       = date( 'Y-m-d', $from );
+	$working_times = kbs_get_support_hours();
+	$next_open     = false;
+
+	for( $i = 1; $i <= 7; $i++ )	{
+		$current = date( 'Y-m-d', strtotime( $current . ' +1 day' ) );
+		$hour    = false;
+		$min     = false;
+
+		if ( ! empty( $working_times[ date( 'w', strtotime( $current ) ) ]['closed'] ) )	{
+			continue;
+		}
+
+		if ( '-1' != $working_times[ date( 'w', strtotime( $current ) ) ]['open']['hour'] )	{
+			$hour = $working_times[ date( 'w', strtotime( $current ) ) ]['open']['hour'];
+		}
+		if ( '-1' !=  $working_times[ date( 'w', strtotime( $current ) ) ]['open']['min'] )	{
+			$min = $working_times[ date( 'w', strtotime( $current ) ) ]['open']['min'];
+		}
+
+		if ( ! empty( $hour ) && ! empty( $min ) )	{
+			$next_open = strtotime( $current . ' ' . $hour . ':' . $min );
+			break;
+		}
+
+	}
+	
+	return $next_open;
+
+} // kbs_get_next_working_day


### PR DESCRIPTION
An SLA target should consider the times at which the support
organisation is open for business. For example, if open hours are
0900-1200 every day. An SLA target of 4 hours from 0900 one day should
return 1000 hours the following day